### PR TITLE
Add targetBookFormat to projectSchema

### DIFF
--- a/core/models/project.ts
+++ b/core/models/project.ts
@@ -2,6 +2,37 @@ import { analyzedPhotoSchema } from "@/core/models/photo";
 import { type Surface, isSpread, surfaceSchema } from "@/core/models/surface";
 import { z } from "zod/v4";
 
+const bookFormatSchema = z.object({
+  pageType: z.string().optional(),
+  skuPageRange: z.array(z.number()).optional(),
+  startFromLeftSide: z.boolean().optional(),
+  targetPageRange: z.array(z.number()),
+  page: z.object({
+    width: z.number(),
+    height: z.number(),
+  }),
+  cover: z.object({
+    width: z.number(),
+    height: z.number(),
+  }),
+  coverWrap: z
+    .object({
+      top: z.number(),
+      right: z.number(),
+      bottom: z.number(),
+      left: z.number(),
+    })
+    .optional(),
+  bleed: z
+    .object({
+      top: z.number(),
+      right: z.number(),
+      bottom: z.number(),
+      left: z.number(),
+    })
+    .optional(),
+});
+
 export const projectSchema = z.object({
   title: z.string().optional(),
   subtitle: z.string().optional(),
@@ -11,36 +42,8 @@ export const projectSchema = z.object({
   imageFilteringLevel: z.string(),
   imageDensityLevel: z.string(),
   embellishmentLevel: z.string(),
-  bookFormat: z.object({
-    pageType: z.string().optional(),
-    skuPageRange: z.array(z.number()).optional(),
-    startFromLeftSide: z.boolean().optional(),
-    targetPageRange: z.array(z.number()),
-    page: z.object({
-      width: z.number(),
-      height: z.number(),
-    }),
-    cover: z.object({
-      width: z.number(),
-      height: z.number(),
-    }),
-    coverWrap: z
-      .object({
-        top: z.number(),
-        right: z.number(),
-        bottom: z.number(),
-        left: z.number(),
-      })
-      .optional(),
-    bleed: z
-      .object({
-        top: z.number(),
-        right: z.number(),
-        bottom: z.number(),
-        left: z.number(),
-      })
-      .optional(),
-  }),
+  bookFormat: bookFormatSchema,
+  targetBookFormat: bookFormatSchema.optional(),
   images: z.array(analyzedPhotoSchema),
   surfaces: z.array(surfaceSchema),
 });

--- a/packages/web-sdk/README.md
+++ b/packages/web-sdk/README.md
@@ -228,6 +228,7 @@ await api.projects.resize({
       left: 0.0625
     } // optional
   },
+  targetBookFormat: {...}, // optional - same schema as bookFormat
   images: [...],
   surfaces: [surface1, surface2, ...]
 });


### PR DESCRIPTION
## Summary
- Extract shared `bookFormatSchema` from inline definition in `projectSchema`
- Add optional `targetBookFormat` field reusing the same schema

## Test plan
- [ ] Verify existing `bookFormat` usage is unaffected
- [ ] Verify `targetBookFormat` is accepted when provided and optional when omitted