### PR TITLE
[core/models] encode embeddings

### DIFF
--- a/core/models/api/endpoints/projects/index.ts
+++ b/core/models/api/endpoints/projects/index.ts
@@ -5,6 +5,7 @@ import {
   type projectAutofillBodySchema,
   projectAutofillTimeoutDelay,
 } from "@/core/models/project";
+import { encodeEmbedding, type AnalyzedPhoto } from "@/core/models/photo";
 import type { MagicBookAPI } from "../..";
 import type { z } from "zod/v4";
 import { formatObject } from "@/core/utils/toolbox";
@@ -43,7 +44,13 @@ export class ProjectEndpoints {
           headers: {
             "magic-request-id": request.id,
           },
-          body: this.magicBookAPI.bodyParse(body),
+          body: this.magicBookAPI.bodyParse({
+            ...body,
+            images: body.images.map((image: AnalyzedPhoto) => ({
+              ...image,
+              embedding: image.embedding ? encodeEmbedding(image.embedding) : undefined,
+            })),
+          }),
         },
         factory: async () => {
           Array.from({ length: faker.number.int({ max: 10, min: 2 }) }, () =>

--- a/core/models/photo.ts
+++ b/core/models/photo.ts
@@ -88,6 +88,15 @@ export type AnalyzedPhoto = z.infer<typeof analyzedPhotoSchema>;
 export type Label = z.infer<typeof labelSchema>;
 export type Face = z.infer<typeof faceSchema>;
 
+export function encodeEmbedding(floats: number[]): string {
+  const bytes = new Uint8Array(new Float32Array(floats).buffer);
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
 export function photoDeprecationCheck(events: DispatcherEvent[], addEvent: AddEvent, requestId: string) {
   const analyzedPhotos = events
     .filter((event) => event.name === "photo.analyzed" && event.message?.result)


### PR DESCRIPTION
### Encode image embeddings as base64 for POST /projects/autofill

The backend now accepts embeddings as a base64-encoded little-endian float32 array. This is ~45% smaller on the wire than JSON-serialised floats (~1,368 vs ~2,500+ chars per embedding).

**What changed:**

- `encodeEmbedding(floats: number[]): string` added to `photo.ts` — packs a `number[]` into a `Float32Array`, reads the raw bytes, and base64-encodes them via `btoa`. The byte-by-byte loop avoids the stack overflow risk of spreading large `Uint8Arrays` into `String.fromCharCode`.
- `autofill` in `ProjectEndpoints` maps each image through encodeEmbedding before bodyParse serialises the body. The transform is scoped to this endpoint — no other serialisation paths are affected.

**What didn't change**
- `AnalyzedPhoto.embedding` type remains `number[] | undefined` — callers are unaffected.
- The backend continues to accept the old `number[]` format, so any other client or SDK version sending raw floats still works.